### PR TITLE
Add units

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -5,3 +5,4 @@
 ^\.gitignore$
 ^readme.Rmd$
 ^readme.md$
+^LICENSE.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: MarineTides
 Type: Package
 Title: Tide Prediction
-Version: 0.1-1
+Version: 0.2-1
 Authors@R: as.person("Are Strom <are.strom@gmail.com> [aut, cre]")
 Maintainer: Are Strom <are.strom@gmail.com>
 Description: Generates tide predictions using harmonics data obtained from the NOAA CO-OPS

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -20,7 +20,7 @@ Imports:
     data.table (>= 1.14.0),
     glue (>= 1.7.0),
     units (>= 0.8)
-License: GPL-3 + file LICENSE
+License: GPL-3
 Encoding: UTF-8
 LazyData: true
 RoxygenNote: 7.3.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -18,7 +18,8 @@ Depends: R (>= 4.3)
 Imports:
     anytime (>= 0.3.9),
     data.table (>= 1.14.0),
-    glue (>= 1.7.0)
+    glue (>= 1.7.0),
+    units (>= 0.8-5)
 License: GPL-3 + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Imports:
     anytime (>= 0.3.9),
     data.table (>= 1.14.0),
     glue (>= 1.7.0),
-    units (>= 0.8-5)
+    units (>= 0.8)
 License: GPL-3 + file LICENSE
 Encoding: UTF-8
 LazyData: true

--- a/R/MarineTides-package.R
+++ b/R/MarineTides-package.R
@@ -39,4 +39,7 @@ if(getRversion() >= "2.15.1")  utils::globalVariables(c("timezone",
                                                         "height_offset_low_tide",
                                                         "offset_level",
                                                         "offset_time",
-                                                        "height_offset_type"))
+                                                        "height_offset_type",
+                                                        "m",
+                                                        "tide_level_ft",
+                                                        "ft"))

--- a/R/TideLevels.R
+++ b/R/TideLevels.R
@@ -142,10 +142,10 @@ tide_level = function(tide_station = "Seattle",
     stop("Tide unit argument must be either meters or feet")
   }
   if ( tide_unit == "meters" ) {
-    tide_out[, tide_level := set_units(tide_level, m)]
+    tide_out[, tide_level := units::set_units(tide_level, m)]
   } else {
-    tide_out[, tide_level := set_units(tide_level, m)]
-    tide_out[, tide_level_ft := set_units(tide_level, ft)]
+    tide_out[, tide_level := units::set_units(tide_level, m)]
+    tide_out[, tide_level_ft := units::set_units(tide_level, ft)]
     tide_out = tide_out[, list(station_code, station_name,
                                reference_station_code,
                                tide_type, tide_time,

--- a/R/TideLevels.R
+++ b/R/TideLevels.R
@@ -12,8 +12,9 @@
 #' @param end_date A character field for the end date of the tide prediction time-span
 #' @param data_interval A character value for the time increment between predictions.
 #'   Allowable options include \code{1-min 6-min, 15-min, 30-min, 60-min, high-low, high-only, low-only}
-#' @param timezone Typically the timezone of the \code{tide_station}, but can also be set manually.
-#' @param verbose A boolean requesting additional information be printed to the R console.
+#' @param tide_unit A character value for the tide level unit. Allowable options are \code{meters, feet}
+#' @param timezone Typically the timezone of the \code{tide_station}, but can also be set manually
+#' @param verbose A boolean requesting additional information be printed to the R console
 #' @param harms Harmonics data
 #'
 #' @details
@@ -56,7 +57,7 @@
 #'   \item{reference_station_code}{Station ID for the reference station (chr).}
 #'   \item{tide_type}{Harmonic or Subordinate (chr).}
 #'   \item{tide_time}{Datetime of the prediction (time).}
-#'   \item{MLLW}{Tide level in meters (dbl).}
+#'   \item{tide_level}{Tide level in specified units, either meters or feet (dbl).}
 #' }
 #'
 #' @export
@@ -64,6 +65,7 @@ tide_level = function(tide_station = "Seattle",
                       start_date = Sys.Date(),
                       end_date = Sys.Date() + 1,
                       data_interval = "15-min",
+                      tide_unit = "meters",
                       timezone = NULL,
                       verbose = FALSE,
                       harms = MarineTides::harmonics) {
@@ -134,6 +136,20 @@ tide_level = function(tide_station = "Seattle",
                                  reference_station_code,
                                  tide_type, tide_time, tide_level)]
     tide_out = tide_pred
+  }
+  # Tide_unit
+  if ( !tide_unit %in% c("meters", "feet") ) {
+    stop("Tide unit argument must be either meters or feet")
+  }
+  if ( tide_unit == "meters" ) {
+    tide_out[, tide_level := set_units(tide_level, m)]
+  } else {
+    tide_out[, tide_level := set_units(tide_level, m)]
+    tide_out[, tide_level_ft := set_units(tide_level, ft)]
+    tide_out = tide_out[, list(station_code, station_name,
+                               reference_station_code,
+                               tide_type, tide_time,
+                               tide_level = tide_level_ft)]
   }
   tide_out = tide_out[inrange(tide_time, min(report_dts), max(report_dts))]
   return(tide_out)

--- a/README.Rmd
+++ b/README.Rmd
@@ -138,9 +138,9 @@ todays_tide[, .(station_code, station_name, tide_time, tide_level)]
 # Then entering a few more letters will allow filtering to a unique station
 subordinate_tide = tide_level("Whitney Point",
                    start_date = "2024-03-11",
-                   end_date = "2024-03- 12",
+                   end_date = "2024-03-12",
                    data_interval = "low-only",
-                   tide_level = "feet",
+                   tide_unit = "feet",
                    verbose = TRUE)
 subordinate_tide[, .(station_code, station_name, tide_time, tide_level)]
 ```

--- a/README.Rmd
+++ b/README.Rmd
@@ -130,7 +130,7 @@ library(MarineTides)
 
 # With no arguments, outputs a data.table of today's tide at Seattle, WA in 15 minute increments.
 todays_tide = tide_level()
-todays_tide[, .(station_code, station_name, tide_time, tide_level_ft = tide_level * 3.28084)]
+todays_tide[, .(station_code, station_name, tide_time, tide_level)]
 
 # To search for a station, try entering part of the name. Message will include list of possible matches.
 # tide_level(tide_station = "Whitney")
@@ -140,8 +140,9 @@ subordinate_tide = tide_level("Whitney Point",
                    start_date = "2024-03-11",
                    end_date = "2024-03- 12",
                    data_interval = "low-only",
+                   tide_level = "feet",
                    verbose = TRUE)
-subordinate_tide[, .(station_code, station_name, tide_time, tide_level_ft = tide_level * 3.28084)]
+subordinate_tide[, .(station_code, station_name, tide_time, tide_level)]
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -116,20 +116,20 @@ library(MarineTides)
 
 # With no arguments, outputs a data.table of today's tide at Seattle, WA in 15 minute increments.
 todays_tide = tide_level()
-todays_tide[, .(station_code, station_name, tide_time, tide_level_ft = tide_level * 3.28084)]
-#>      station_code station_name           tide_time tide_level_ft
-#>            <char>       <char>              <POSc>         <num>
-#>   1:      9447130      Seattle 2024-03-10 00:00:00      1.176399
-#>   2:      9447130      Seattle 2024-03-10 00:15:00      1.813860
-#>   3:      9447130      Seattle 2024-03-10 00:30:00      2.501474
-#>   4:      9447130      Seattle 2024-03-10 00:45:00      3.229126
-#>   5:      9447130      Seattle 2024-03-10 01:00:00      3.986435
-#>  ---                                                            
-#> 184:      9447130      Seattle 2024-03-11 22:45:00      3.784929
-#> 185:      9447130      Seattle 2024-03-11 23:00:00      3.212155
-#> 186:      9447130      Seattle 2024-03-11 23:15:00      2.687703
-#> 187:      9447130      Seattle 2024-03-11 23:30:00      2.223222
-#> 188:      9447130      Seattle 2024-03-11 23:45:00      1.829389
+todays_tide[, .(station_code, station_name, tide_time, tide_level)]
+#>      station_code station_name           tide_time   tide_level
+#>            <char>       <char>              <POSc>      <units>
+#>   1:      9447130      Seattle 2024-06-15 00:00:00 3.320440 [m]
+#>   2:      9447130      Seattle 2024-06-15 00:15:00 3.336625 [m]
+#>   3:      9447130      Seattle 2024-06-15 00:30:00 3.338127 [m]
+#>   4:      9447130      Seattle 2024-06-15 00:45:00 3.325300 [m]
+#>   5:      9447130      Seattle 2024-06-15 01:00:00 3.298657 [m]
+#>  ---                                                           
+#> 188:      9447130      Seattle 2024-06-16 22:45:00 2.594660 [m]
+#> 189:      9447130      Seattle 2024-06-16 23:00:00 2.683913 [m]
+#> 190:      9447130      Seattle 2024-06-16 23:15:00 2.772680 [m]
+#> 191:      9447130      Seattle 2024-06-16 23:30:00 2.859218 [m]
+#> 192:      9447130      Seattle 2024-06-16 23:45:00 2.941645 [m]
 
 # To search for a station, try entering part of the name. Message will include list of possible matches.
 # tide_level(tide_station = "Whitney")
@@ -137,8 +137,9 @@ todays_tide[, .(station_code, station_name, tide_time, tide_level_ft = tide_leve
 # Then entering a few more letters will allow filtering to a unique station
 subordinate_tide = tide_level("Whitney Point",
                    start_date = "2024-03-11",
-                   end_date = "2024-03- 12",
+                   end_date = "2024-03-12",
                    data_interval = "low-only",
+                   tide_unit = "feet",
                    verbose = TRUE)
 #> Whitney Point, Dabob Bay is a subordinate station. The reference station, 
 #> Seattle, is located 42.23 km. away. Tide levels are 
@@ -148,13 +149,13 @@ subordinate_tide = tide_level("Whitney Point",
 #> Whitney Point, Dabob Bay predictions. 
 #> 
 #> Tides will be predicted from 2024-03-11 to 2024-03-12
-subordinate_tide[, .(station_code, station_name, tide_time, tide_level_ft = tide_level * 3.28084)]
-#>    station_code             station_name           tide_time tide_level_ft
-#>          <char>                   <char>              <POSc>         <num>
-#> 1:      9445246 Whitney Point, Dabob Bay 2024-03-11 00:01:00    -0.2454090
-#> 2:      9445246 Whitney Point, Dabob Bay 2024-03-11 12:41:00     2.0966150
-#> 3:      9445246 Whitney Point, Dabob Bay 2024-03-12 00:45:00     1.1837560
-#> 4:      9445246 Whitney Point, Dabob Bay 2024-03-12 13:25:00     0.7557052
+subordinate_tide[, .(station_code, station_name, tide_time, tide_level)]
+#>    station_code             station_name           tide_time      tide_level
+#>          <char>                   <char>              <POSc>         <units>
+#> 1:      9445246 Whitney Point, Dabob Bay 2024-03-11 00:01:00 -0.2454090 [ft]
+#> 2:      9445246 Whitney Point, Dabob Bay 2024-03-11 12:41:00  2.0966149 [ft]
+#> 3:      9445246 Whitney Point, Dabob Bay 2024-03-12 00:45:00  1.1837560 [ft]
+#> 4:      9445246 Whitney Point, Dabob Bay 2024-03-12 13:25:00  0.7557052 [ft]
 ```
 
 ## Disclaimers

--- a/man/tide_level.Rd
+++ b/man/tide_level.Rd
@@ -11,7 +11,7 @@ A data.frame:
   \item{reference_station_code}{Station ID for the reference station (chr).}
   \item{tide_type}{Harmonic or Subordinate (chr).}
   \item{tide_time}{Datetime of the prediction (time).}
-  \item{MLLW}{Tide level in meters (dbl).}
+  \item{tide_level}{Tide level in specified units, either meters or feet (dbl).}
 }
 }
 \usage{
@@ -20,6 +20,7 @@ tide_level(
   start_date = Sys.Date(),
   end_date = Sys.Date() + 1,
   data_interval = "15-min",
+  tide_unit = "meters",
   timezone = NULL,
   verbose = FALSE,
   harms = MarineTides::harmonics
@@ -35,9 +36,11 @@ tide_level(
 \item{data_interval}{A character value for the time increment between predictions.
 Allowable options include \code{1-min 6-min, 15-min, 30-min, 60-min, high-low, high-only, low-only}}
 
-\item{timezone}{Typically the timezone of the \code{tide_station}, but can also be set manually.}
+\item{tide_unit}{A character value for the tide level unit. Allowable options are \code{meters, feet}}
 
-\item{verbose}{A boolean requesting additional information be printed to the R console.}
+\item{timezone}{Typically the timezone of the \code{tide_station}, but can also be set manually}
+
+\item{verbose}{A boolean requesting additional information be printed to the R console}
 
 \item{harms}{Harmonics data}
 }


### PR DESCRIPTION
Added `tide_units` argument to allow outputting tide levels in units of either meters or feet.